### PR TITLE
Updates: Center single postdoc and move Trivedi & Zdimal to alumni

### DIFF
--- a/app/people/_data.js
+++ b/app/people/_data.js
@@ -12,18 +12,6 @@ const content = {
         about:
           'I am passionate about understanding how bacteria regulate complex physiological traits, especially ones that determine association with hosts. My current research includes understanding the regulation and biophysics of T9SS-mediated gliding motility. I use tools from ranging from bacterial genetics, protein biochemistry, microscopy and computational biology. Outside the lab, I like capturing stories on CMOS sensors.',
         photo: require('../../public/images/Jitendra Gosai.png')
-      },
-      {
-        name: 'Abhishek Trivedi, PhD',
-        about:
-          'I am interested in learning more about the fundamentals of bacterial locomotion and deciphering the mechanism by which the type 9 secretion system controls gliding. I have a PhD in microbiology, and I am currently broadening my expertise by learning biophysics and computational biology. I am interested in doing fundamental microbiology research in future and I plan to stay in academics. Beside academics, I am interested reading literature, playing table tennis, running and cricket. ',
-        photo: require('../../public/images/Abhishek Trivedi.png')
-      },
-      {
-        name: 'Amanda Zdimal, PhD',
-        about:
-          'I am curious about the interactions between bacterial cells, their products, and the underlying mechanisms that influence human health. I aim to characterize spatial and temporal development of polymicrobial communities present in human mouth and gut. Since the oral and gut microbiomes have been implicated in numerous diseases, information regarding the microbial profile and development of community structure may provide new insights into the mechanisms which dictate healthy and disease states in humans.',
-        photo: require('../../public/images/Amanda Zdimal.png')
       }
     ],
     'PhD students': [
@@ -79,6 +67,17 @@ const content = {
       }
     ],
     'Lab alumni': [
+      
+      {
+        name: 'Abhishek Trivedi, PhD',
+        about: '',
+        photo: require('../../public/images/Abhishek Trivedi.png')
+      },
+      {
+        name: 'Amanda Zdimal, PhD',
+        about: '',
+        photo: require('../../public/images/Amanda Zdimal.png')
+      },
       {
         name: 'Maxim Averbukh',
         about: '',

--- a/app/people/page.js
+++ b/app/people/page.js
@@ -11,11 +11,12 @@ function PeopleComponent() {
       <h1 className='text-5xl lg:text-7xl  top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 font-serif text-white absolute'>People</h1>
     </div>
   )
-
-  const renderStudentData = (studentType = 'Postdoctoral Fellows') => (
+  const renderStudentData = (studentType = 'Postdoctoral Fellows') => {
+  const isSingle = content.students[studentType].length === 1
+  return (
     <div className='mt-10'>
       <p className='text-red-800 font-bold text-xl py-5 underline'>{studentType}</p>
-      <div className='flex flex-col md:flex-row xl:flex-row items-base justify-normal flex-wrap'>
+      <div className={`flex flex-col md:flex-row xl:flex-row items-base flex-wrap ${isSingle ? 'justify-center' : 'justify-normal'}`}>
         {content.students[studentType].map((student, index) => (
           <section key={index} className='basis-1/3 py-5 md:px-5 xl:p-5'>
             <Image src={student.photo} alt={student.name} className='w-96 h-auto md:h-auto md:w-72 xl:h-auto xl:w-96 py-5' />
@@ -26,6 +27,7 @@ function PeopleComponent() {
       </div>
     </div>
   )
+}
 
   const renderContent = () => (
     <div className='xl:px-80 md:px-12 px-8 py-10 font-serif text-center '>


### PR DESCRIPTION
This pull request updates the people data and improves the layout logic for displaying lab members on the "People" page. The main changes include moving two members from the "Postdoctoral Fellows" section to "Lab alumni" and updating the layout to better handle sections with only one member.

**Data updates:**

* Moved `Abhishek Trivedi, PhD` and `Amanda Zdimal, PhD` from the "Postdoctoral Fellows" section to the "Lab alumni" section in `app/people/_data.js`, and removed their detailed bios from the data. [[1]](diffhunk://#diff-2ee0fdb9ce38ae549497a55d8ba5b5b4839913b4000df6c258d8976b610bc2a9L15-L26) [[2]](diffhunk://#diff-2ee0fdb9ce38ae549497a55d8ba5b5b4839913b4000df6c258d8976b610bc2a9R70-R80)

**Layout improvements:**

* Updated the `renderStudentData` function in `app/people/page.js` to center the display when a section contains only one member, improving the visual layout for single-member sections.
* Fixed the function structure in `app/people/page.js` by properly closing the `renderStudentData` function.